### PR TITLE
SRE-2001 Change dependency from unmaintained library to yext fork.

### DIFF
--- a/net/discovery/service.go
+++ b/net/discovery/service.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/curator-go/curator"
+	"github.com/yext/curator"
 )
 
 type ServiceDiscovery struct {

--- a/net/discovery/service_test.go
+++ b/net/discovery/service_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/curator-go/curator"
 	"github.com/samuel/go-zookeeper/zk"
+	"github.com/yext/curator"
 )
 
 func getTestCluster(t *testing.T) *zk.TestCluster {

--- a/net/discovery/tree_cache.go
+++ b/net/discovery/tree_cache.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"sync"
 
-	"github.com/curator-go/curator"
 	"github.com/samuel/go-zookeeper/zk"
+	"github.com/yext/curator"
 )
 
 type TreeCache struct {


### PR DESCRIPTION
We want to change our dependency from github.com/curator-go/curator to github.com/yext/curator as we want certain fixes that are pushed to Yext's fork of `curator` but don't exist in the parent library as it is unmaintained.