### PR TITLE
Dawei zhang y patch 1 (#1)

### DIFF
--- a/net/discovery/service_test.go
+++ b/net/discovery/service_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/yext/curator"
 )
 

--- a/net/discovery/tree_cache.go
+++ b/net/discovery/tree_cache.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 	"github.com/yext/curator"
 )
 


### PR DESCRIPTION
    Update Zookeeper Go library to latest

    This is to resolve a Curator bug that, when zookeeper is down curator
    panic instead of waiting for reconnecting

    J=SRE-2654
    TEST=manual

    Test a RPC server locally connected to a local Zookeeper instance.
    Observed RPC server behavior while shutting down zookeeper instance.